### PR TITLE
Less strict type for Query

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ And for dynamic routes, the type is always:
 **Example**:
 
 ```ts
-type Query = { [key: string]: string | number };
+type Query = { [key: string]: any };
 export type TypeSafePage =
   | "/users"
   | { route: "/users"; query?: Query }

--- a/example/src/@types/next-type-safe-routes/index.d.ts
+++ b/example/src/@types/next-type-safe-routes/index.d.ts
@@ -2,7 +2,7 @@
 // package. You should _not_ update these types manually...
 
 declare module "next-type-safe-routes" {
-  type Query = { [key: string]: string | number };
+  type Query = { [key: string]: any };
   export type TypeSafePage = "/" | { route: "/", query?: Query } | { route: "/users/[userId]", params: { userId: string | string[] | number }, query?: Query } | "/users" | { route: "/users", query?: Query };
   export type TypeSafeApiRoute = "/api/mocks" | { route: "/api/mocks", query?: Query } | { route: "/api/users/[userId]", params: { userId: string | string[] | number }, query?: Query } | "/api/users" | { route: "/api/users", query?: Query };
   export const getPathname = (typeSafeUrl: TypeSafePage | TypeSafeApiRoute) => string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-type-safe-routes",
-  "version": "0.2.0-alpha",
+  "version": "0.2.0-alpha.1",
   "description": "Never should your users experience broken links again!",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/plugin/generateTypeScriptFile/__snapshots__/generateTypeScriptFile.test.ts.snap
+++ b/src/plugin/generateTypeScriptFile/__snapshots__/generateTypeScriptFile.test.ts.snap
@@ -5,7 +5,7 @@ exports[`plugin/generateTypeScriptFile works as expected 1`] = `
 // package. You should _not_ update these types manually...
 
 declare module \\"next-type-safe-routes\\" {
-  type Query = { [key: string]: string | number };
+  type Query = { [key: string]: any };
   export type TypeSafePage = \\"/404\\" | { route: \\"/404\\", query?: Query } | \\"/\\" | { route: \\"/\\", query?: Query } | { route: \\"/users/[userId]\\", params: { userId: string | string[] | number }, query?: Query } | \\"/users\\" | { route: \\"/users\\", query?: Query };
   export type TypeSafeApiRoute = { route: \\"/api/[authId]\\", params: { authId: string | string[] | number }, query?: Query } | { route: \\"/api/users/[userId]\\", params: { userId: string | string[] | number }, query?: Query } | \\"/api/users\\" | { route: \\"/api/users\\", query?: Query };
   export const getPathname = (typeSafeUrl: TypeSafePage | TypeSafeApiRoute) => string;

--- a/src/plugin/generateTypeScriptFile/getFileContent.ts
+++ b/src/plugin/generateTypeScriptFile/getFileContent.ts
@@ -24,7 +24,7 @@ const getFileContent = ({
 // package. You should _not_ update these types manually...
 
 declare module "next-type-safe-routes" {
-  type Query = { [key: string]: string | number };
+  type Query = { [key: string]: any };
   export type TypeSafePage = ${pages.map(getTypeSafeRoute).join(" | ")};
   ${
     apiRoutes.length > 0

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 // NOTE, these will be replaced with the "real" TypeSafePage type
 // when generating types for a project
-type Query = { [key: string]: string | number };
+type Query = { [key: string]: any };
 type TypeSafePage =
   | string
   | { route: string; query?: Query }


### PR DESCRIPTION
This would cause a type error:

```ts
type QueryTest = {
  a: "b",
}

const query: QueryTest = {
  a: "b",
}

getRoute({ route: '/something', query })
```